### PR TITLE
Add a drupal_alter function to allow changing checkout request parameters

### DIFF
--- a/commerce_2checkout/commerce_2checkout.api.php
+++ b/commerce_2checkout/commerce_2checkout.api.php
@@ -26,3 +26,12 @@ function hook_commerce_2checkout_order_form_data_alter(&$data, $order) {
     $i++;
   }
 }
+
+/**
+ * Implements hook_commerce_2checkout_validate_form_data_alter().
+ */
+function hook_commerce_2checkout_validate_form_data_alter(&$data, $order) {
+  $USD_BOB = (float) variable_get('currency_usd_2_bob', 6.97);
+
+  $data['total'] = number_format((float) $data['total'] * $USD_BOB, 2, '.', '');
+}

--- a/commerce_2checkout/commerce_2checkout.api.php
+++ b/commerce_2checkout/commerce_2checkout.api.php
@@ -17,5 +17,12 @@
  * @see commerce_2checkout_purchase_parameters()
  */
 function hook_commerce_2checkout_order_form_data_alter(&$data, $order) {
-  unset($data['currency_code']);
+  $USD_BOB = (float) variable_get('currency_usd_2_bob', 6.97);
+  $data['currency_code'] = 'USD';
+
+  $i = 0;
+  foreach ($order->commerce_line_items[LANGUAGE_NONE] as $li) {
+    $data['li_' . $i . '_price'] = number_format((float) $data['li_' . $i . '_price'] / $USD_BOB, 2, '.', '');
+    $i++;
+  }
 }

--- a/commerce_2checkout/commerce_2checkout.api.php
+++ b/commerce_2checkout/commerce_2checkout.api.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Documents hooks provided by the Commerce 2Checkout module.
+ */
+
+
+/**
+ * Allows modules to alter the data array used to create the request form.
+ *
+ * @param &$data
+ *   The data array used to create the request form elements.
+ * @param $order
+ *   The full order object the request form is being generated for.
+ *
+ * @see commerce_2checkout_purchase_parameters()
+ */
+function hook_commerce_2checkout_order_form_data_alter(&$data, $order) {
+  unset($data['currency_code']);
+}

--- a/commerce_2checkout/commerce_2checkout.module
+++ b/commerce_2checkout/commerce_2checkout.module
@@ -172,6 +172,10 @@ function commerce_2checkout_redirect_form_validate($order, $payment_method) {
     commerce_order_status_update($order, 'completed');
     commerce_order_save ($order);
     // Save the transaction information.
+
+    // Allow modules to alter parameters of the API response.
+    drupal_alter('commerce_2checkout_validate_form_data', $_REQUEST, $order);
+
     $transaction = commerce_payment_transaction_new('2checkout', $_REQUEST['merchant_order_id']);
     $transaction->instance_id = $payment_method['instance_id'];
     $transaction->amount = commerce_currency_decimal_to_amount($_REQUEST['total'], commerce_default_currency());

--- a/commerce_2checkout/commerce_2checkout.module
+++ b/commerce_2checkout/commerce_2checkout.module
@@ -315,6 +315,9 @@ function commerce_2checkout_purchase_parameters ($order, $settings) {
   if ($settings['demo'] == 1)
     $data['demo'] = 'Y';
 
+  // Allow modules to alter parameters of the API request.
+  drupal_alter('commerce_2checkout_order_form_data', $data, $order);
+
   return $data;
 }
 


### PR DESCRIPTION
Add a drupal_alter function to allow changing checkout request parameters. For example, in my case I have a store with a non supported currency, so I need to change the currency before sending the request.
